### PR TITLE
Fix: Adjust import path for Order model in orders.js to CommonJS syntax

### DIFF
--- a/src/routes/orders.js
+++ b/src/routes/orders.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { body, validationResult } from 'express-validator';
-import Order from '../models/Order.js';
+const Order = require('../models/Order');
 
 const router = express.Router();
 


### PR DESCRIPTION

Este commit corrige la importación del modelo Order en el archivo orders.js, cambiándola de la sintaxis ES Modules (import) a CommonJS (require). Dado que se eliminó "type": "module" del package.json, ahora todo el proyecto utiliza la sintaxis CommonJS para asegurar la compatibilidad en Heroku.

La nueva ruta relativa en orders.js es require('../models/Order'), asegurando que el modelo se importe correctamente. Esto resuelve el problema de compatibilidad de importación/exportación y permite que el código se ejecute sin errores de módulo en el entorno de producción de Heroku.
