### PR TITLE
Fix: Change postcss.config.js to use CommonJS syntax

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION

Este commit cambia la configuración de exportación en postcss.config.js de la sintaxis ES Modules (export default) a CommonJS (module.exports). 

Dado que se eliminó "type": "module" del package.json, ahora todos los archivos deben usar la sintaxis CommonJS para asegurar la compatibilidad en el entorno de despliegue de Heroku. Este ajuste permite que Vite y PostCSS se configuren correctamente sin generar errores de sintaxis en producción.

La nueva configuración asegura que Heroku pueda compilar el proyecto sin problemas relacionados con la carga de PostCSS.
