### PR TITLE
Fix: Remove redundant __dirname declaration for CommonJS compatibility

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -12,7 +12,7 @@ const paymentRoutes = require('./routes/payment');
 dotenv.config();
 
 const app = express();
-const __dirname = dirname(fileURLToPath(import.meta.url));
+//const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Connect to MongoDB
 connectDB().catch((error) => {


### PR DESCRIPTION


Este commit elimina la declaración manual de __dirname en server.js, ya que en CommonJS __dirname está disponible globalmente. Este cambio asegura que no se produzca un error de "Identifier '__dirname' has already been declared" y que el servidor funcione correctamente en el entorno de Heroku.

Ahora se utiliza __dirname directamente donde es necesario, sin definirlo explícitamente.
