### PR TITLE
Fix: Convert export in database.js to CommonJS syntax

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -10,4 +10,4 @@ const connectDB = async () => {
   }
 };
 
-export default connectDB;
+module.exports = connectDB;


### PR DESCRIPTION

Este commit cambia la exportación de connectDB en database.js de la sintaxis ES Modules (export default) a CommonJS (module.exports). Este ajuste es necesario para que el archivo sea compatible con la configuración de CommonJS en el proyecto tras la eliminación de "type": "module" en package.json.

También se asegura que server.js importe connectDB usando require, evitando errores de importación en el entorno de Heroku.
