### PR TITLE
Fix: Convert products.js to CommonJS syntax for compatibility

### DIFF
--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -1,6 +1,6 @@
-import express from 'express';
-import { body, validationResult } from 'express-validator';
-import Product from '../models/Product.js';
+const express = require('express');
+const { body, validationResult } = require('express-validator');
+const Product = require('../models/Product');
 
 const router = express.Router();
 
@@ -28,7 +28,8 @@ router.get('/:id', async (req, res) => {
 });
 
 // Create product
-router.post('/',
+router.post(
+  '/',
   [
     body('name').notEmpty(),
     body('price').isNumeric(),
@@ -51,6 +52,7 @@ router.post('/',
     } catch (error) {
       res.status(400).json({ message: error.message });
     }
-});
+  }
+);
 
-export default router;
+module.exports = router;


### PR DESCRIPTION

Este commit cambia la sintaxis de importación y exportación en products.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json. 

Este ajuste resuelve el error "Cannot use import statement outside a module" en este archivo de rutas.
