### PR TITLE
Fix: Convert Product.js to CommonJS syntax for compatibility

### DIFF
--- a/src/models/Product.js
+++ b/src/models/Product.js
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+const mongoose = require('mongoose');
 
 const productSchema = new mongoose.Schema({
   name: {
@@ -34,4 +34,4 @@ const productSchema = new mongoose.Schema({
   timestamps: true,
 });
 
-export default mongoose.model('Product', productSchema);
+module.exports = mongoose.model('Product', productSchema);


### PR DESCRIPTION
Este commit cambia la sintaxis de importación y exportación en Product.js de ES Modules (import/export) a CommonJS (require/module.exports). 

Este cambio asegura que el modelo de producto sea compatible con la configuración de CommonJS en el proyecto, permitiendo que Heroku cargue correctamente el archivo sin errores de sintaxis relacionados con ES Modules.
