### PR TITLE
Fix: Convert users.js to CommonJS syntax for compatibility

### DIFF
--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,13 +1,14 @@
-import express from 'express';
-import bcrypt from 'bcryptjs';
-import jwt from 'jsonwebtoken';
-import { body, validationResult } from 'express-validator';
-import User from '../models/User.js';
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { body, validationResult } = require('express-validator');
+const User = require('../models/User');
 
 const router = express.Router();
 
 // Register user
-router.post('/register',
+router.post(
+  '/register',
   [
     body('name').notEmpty(),
     body('email').isEmail(),
@@ -52,10 +53,12 @@ router.post('/register',
     } catch (error) {
       res.status(500).json({ message: error.message });
     }
-});
+  }
+);
 
 // Login user
-router.post('/login',
+router.post(
+  '/login',
   [
     body('email').isEmail(),
     body('password').exists(),
@@ -92,6 +95,7 @@ router.post('/login',
     } catch (error) {
       res.status(500).json({ message: error.message });
     }
-});
+  }
+);
 
-export default router;
+module.exports = router;


### PR DESCRIPTION
Este commit cambia la sintaxis de importación y exportación en users.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json.

Este ajuste resuelve el error "Cannot use import statement outside a module" en este archivo de rutas.
