### PR TITLE
Fix: Convert User.js to CommonJS syntax for compatibility

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+const mongoose = require('mongoose');
 
 const userSchema = new mongoose.Schema({
   name: {
@@ -25,4 +25,4 @@ const userSchema = new mongoose.Schema({
   timestamps: true,
 });
 
-export default mongoose.model('User', userSchema);
+module.exports = mongoose.model('User', userSchema);


### PR DESCRIPTION


Este commit cambia la sintaxis de importación y exportación en User.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json.

Este ajuste resuelve el error "Cannot use import statement outside a module" en el modelo de usuario.
