### PR TITLE
Fix: Convert payment.js to CommonJS syntax for compatibility

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -1,7 +1,7 @@
-import express from 'express';
-import { WebpayPlus } from 'transbank-sdk';
-import { transbankConfig } from '../config/transbank.js';
-import { validateMallTransaction } from '../middleware/validateTransaction.js';
+const express = require('express');
+const { WebpayPlus } = require('transbank-sdk');
+const { transbankConfig } = require('../config/transbank');
+const { validateMallTransaction } = require('../middleware/validateTransaction');
 
 const router = express.Router();
 const config = process.env.NODE_ENV === 'production' ? transbankConfig.production : transbankConfig.integration;
@@ -85,4 +85,4 @@ router.post('/mall/confirm', async (req, res) => {
   }
 });
 
-export default router;
+module.exports = router;


### PR DESCRIPTION


Este commit cambia la sintaxis de importación y exportación en payment.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json.

Este ajuste resuelve el error "Cannot use import statement outside a module" en el archivo de rutas de pago.
