### PR TITLE
Fix: Convert transbankConfig to CommonJS syntax for compatibility

### DIFF
--- a/src/config/transbank.js
+++ b/src/config/transbank.js
@@ -1,6 +1,6 @@
-import { Options, IntegrationApiKeys, Environment, IntegrationCommerceCodes } from 'transbank-sdk';
+const { Options, IntegrationApiKeys, Environment, IntegrationCommerceCodes } = require('transbank-sdk');
 
-export const transbankConfig = {
+const transbankConfig = {
   integration: {
     mall: new Options(
       IntegrationCommerceCodes.WEBPAY_PLUS_MALL,
@@ -36,3 +36,5 @@ export const transbankConfig = {
     ]
   }
 };
+
+module.exports = { transbankConfig };


### PR DESCRIPTION


Este commit cambia la sintaxis de importación y exportación en transbankConfig.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json.

Este ajuste resuelve el error "Cannot use import statement outside a module" en el archivo de configuración de Transbank.
