### PR TITLE
Fix: Convert auth.js and validateTransaction.js to CommonJS syntax fo…

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,6 +1,6 @@
-import jwt from 'jsonwebtoken';
+const jwt = require('jsonwebtoken');
 
-export const auth = (req, res, next) => {
+const auth = (req, res, next) => {
   try {
     const token = req.header('Authorization')?.replace('Bearer ', '');
     
@@ -15,3 +15,5 @@ export const auth = (req, res, next) => {
     res.status(401).json({ message: 'Token is not valid' });
   }
 };
+
+module.exports = { auth };

--- a/src/middleware/validateTransaction.js
+++ b/src/middleware/validateTransaction.js
@@ -1,6 +1,6 @@
-import { body, validationResult } from 'express-validator';
+const { body, validationResult } = require('express-validator');
 
-export const validateMallTransaction = [
+const validateMallTransaction = [
   body('items')
     .isArray()
     .withMessage('Los items deben ser un array')
@@ -33,3 +33,5 @@ export const validateMallTransaction = [
     next();
   }
 ];
+
+module.exports = { validateMallTransaction };


### PR DESCRIPTION
Este commit cambia la sintaxis de importación y exportación en auth.js y validateTransaction.js de ES Modules (import/export) a CommonJS (require/module.exports) para asegurar la compatibilidad con el entorno de despliegue de Heroku, donde "type": "module" fue eliminado de package.json.

Este ajuste resuelve el error "Cannot use import statement outside a module" en estos archivos de middleware.
