### PR TITLE
Fix: Remove unsupported Mongoose options in database configuration

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -5,8 +5,6 @@ const connectDB = async () => {
     const conn = await mongoose.connect(process.env.MONGODB_URI, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
-      useCreateIndex: true,  // Ayuda a manejar índices automáticamente
-      useFindAndModify: false  // Evita advertencias de MongoDB
     });
     console.log(`MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {


### PR DESCRIPTION
Este commit elimina las opciones `useCreateIndex` y `useFindAndModify` de la configuración de Mongoose en database.js, ya que no son compatibles con las versiones recientes de Mongoose.

Esto permite que la conexión a MongoDB Atlas se establezca sin errores en la configuración.
