### PR TITLE
Fix: Añade validación para storeIndex en el mapeo de details en la cr…

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -14,11 +14,18 @@ router.post('/mall/create', validateMallTransaction, async (req, res) => {
     const returnUrl = `${process.env.FRONTEND_URL}/payment/result`;
 
     const tx = new WebpayPlus.MallTransaction(config.mall);
-    const details = items.map((item, index) => ({
-      amount: Math.round(item.amount),
-      commerceCode: config.stores[item.storeIndex].commerceCode,
-      buyOrder: `${orderId}-${config.stores[item.storeIndex].commerceCode}`
-    }));
+    const details = items.map((item, index) => {
+      const store = config.stores[item.storeIndex];
+      if (!store) {
+        throw new Error(`Invalid store index: ${item.storeIndex}`);
+      }
+      return {
+        amount: Math.round(item.amount),
+        commerceCode: store.commerceCode,
+        buyOrder: `${orderId}-${store.commerceCode}`
+      };
+    });
+    
 
     const response = await tx.create(
       orderId,


### PR DESCRIPTION
Este cambio incluye una validación para asegurar que storeIndex es válido antes de acceder a config.stores[item.storeIndex].commerceCode, previniendo errores en caso de que storeIndex sea inválido o esté fuera de rango.