### PR TITLE
FIX: Ajuste en buyOrder para cumplir con la longitud máxima permitida…

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -19,6 +19,7 @@ router.post('/mall/create', validateMallTransaction, async (req, res) => {
       if (!store) {
         throw new Error(`Invalid store index: ${item.storeIndex}`);
       }
+      const buyOrder = `${orderId}-${store.commerceCode}`.slice(0, 26);
       return {
         amount: Math.round(item.amount),
         commerceCode: store.commerceCode,


### PR DESCRIPTION
Se implementó una validación en el proceso de creación de transacciones mall para asegurar que el campo buyOrder cumpla con la restricción de longitud máxima de 26 caracteres exigida por el SDK de Transbank. Esto se logró truncando el valor concatenado de orderId y commerceCode mediante .slice(0, 26), evitando así que la longitud de buyOrder exceda el límite permitido.

Esta corrección previene errores de validación al momento de crear la transacción y garantiza que el buyOrder se ajuste al formato requerido, permitiendo una integración fluida con Transbank.