### PR TITLE
Fix: Corrección de URL de Redirección en Webpay Err404

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -10,7 +10,8 @@ router.post('/mall/create', validateMallTransaction, async (req, res) => {
   try {
     const { items, orderId } = req.body;
     const sessionId = `SESSION_${Date.now()}`;
-    const returnUrl = `${process.env.FRONTEND_URL}/payment/result`;
+    const returnUrl = `${process.env.FRONTEND_URL}/payment/result`.replace(/([^:]\/)\/+/g, "$1");
+
 
     const details = items.map((item, index) => {
       const store = transbankConfig.stores[item.storeIndex];


### PR DESCRIPTION
Este fix corrige un problema en la construcción de la URL de redirección (returnUrl) utilizada en la integración con Webpay. Se eliminan los dobles slash (//) en la URL de retorno que estaban causando un error 404 al finalizar la transacción. La URL de redirección ahora se genera correctamente sin barras adicionales, lo que garantiza una navegación adecuada al endpoint /payment/result. Además, se ajusta la variable FRONTEND_URL en Heroku para que no finalice con un slash, asegurando consistencia en la construcción de URLs.