### PR TITLE
Fix: Añadir CartProvider al Nivel Superior de la Aplicación

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,18 +2,31 @@ import { createBrowserRouter } from 'react-router-dom';
 import App from '../App';
 import { MallPaymentResult } from '../components/MallPaymentResult';
 import WebpayRedirectPage from '../components/WebpayRedirectPage';
+import { CartProvider } from '../context/CartContext'; // Importa el CartProvider
 
 export const router = createBrowserRouter([
   {
     path: '/',
-    element: <App />,
+    element: (
+      <CartProvider>
+        <App />
+      </CartProvider>
+    ),
   },
   {
     path: '/payment/result',
-    element: <MallPaymentResult />,
+    element: (
+      <CartProvider>
+        <MallPaymentResult />
+      </CartProvider>
+    ),
   },
   {
     path: '/webpay-redirect',
-    element: <WebpayRedirectPage />,
+    element: (
+      <CartProvider>
+        <WebpayRedirectPage />
+      </CartProvider>
+    ),
   },
 ]);


### PR DESCRIPTION


El error indica que useCart se está utilizando fuera de un CartProvider, lo cual es esencial para proporcionar el contexto del carrito. Esto ocurre probablemente porque la página de resultados de pago (MallPaymentResult) no está envuelta dentro del CartProvider, lo que impide acceder al contexto del carrito.

Para resolver este problema, debes asegurarte de que el CartProvider envuelva toda la aplicación o al menos las rutas que necesitan acceso al carrito.