### PR TITLE
FIX: AddMallTransactionConfirmationRoute

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -5,37 +5,35 @@ const { validateMallTransaction } = require('../middleware/validateTransaction')
 
 const router = express.Router();
 
-// Crear transacción mall
-router.post('/mall/create', validateMallTransaction, async (req, res) => {
+// Confirmar transacción mall
+router.post('/mall/confirm', async (req, res) => {
   try {
-    const { items, orderId } = req.body;
-    const sessionId = `SESSION_${Date.now()}`;
-    const returnUrl = `${process.env.FRONTEND_URL}/payment/result`.replace(/([^:]\/)\/+/g, "$1");
+    const { token_ws } = req.body;
 
-
-    const details = items.map((item, index) => {
-      const store = transbankConfig.stores[item.storeIndex];
-      return new TransactionDetail(
-        Math.round(item.amount),
-        store.commerceCode,
-        `${orderId.slice(0, 10)}-${store.commerceCode}`.slice(0, 26)
-      );
-    });
+    if (!token_ws) {
+      return res.status(400).json({ message: 'Token de transacción faltante' });
+    }
 
     const tx = new WebpayPlus.MallTransaction(transbankConfig.mall);
-    const response = await tx.create(orderId, sessionId, returnUrl, details);
+    const response = await tx.commit(token_ws);
 
-    res.json({
-      token: response.token,
-      url: response.url,
-    });
+    if (response.status === 'AUTHORIZED' && response.response_code === 0) {
+      res.json({
+        status: 'success',
+        response: response,
+      });
+    } else {
+      res.status(400).json({
+        status: 'error',
+        message: 'La transacción no fue autorizada',
+        response: response,
+      });
+    }
   } catch (error) {
-    console.error('Error creating mall transaction:', error);
-    res.status(500).json({ 
-      message: 'Error al procesar el pago', 
-      error: error.message 
+    console.error('Error confirming mall transaction:', error);
+    res.status(500).json({
+      message: 'Error al confirmar el pago',
+      error: error.message,
     });
   }
 });
-
-module.exports = router;


### PR DESCRIPTION

Se añadió la ruta /mall/confirm en el archivo payment.js para manejar la confirmación de transacciones con Webpay Plus en un flujo de pago mall en el ambiente de integración. Esta ruta permite confirmar la transacción y obtener los detalles finales de la autorización, como el monto, el estado de la transacción, el código de autorización y la fecha de la transacción. Además, se configuró el frontend para hacer la llamada a esta nueva ruta al recibir el token_ws en la URL de retorno.