### PR TITLE
FIX: Add missing mall transaction creation route

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -5,6 +5,31 @@ const { validateMallTransaction } = require('../middleware/validateTransaction')
 
 const router = express.Router();
 
+router.post('/mall/create', async (req, res) => {
+  try {
+    const { buyOrder, sessionId, details } = req.body;
+
+    if (!buyOrder || !sessionId || !details || !Array.isArray(details)) {
+      return res.status(400).json({ message: 'Parámetros de transacción faltantes o incorrectos' });
+    }
+
+    const tx = new WebpayPlus.MallTransaction(transbankConfig.mall);
+    const response = await tx.create(buyOrder, sessionId, details, transbankConfig.returnUrl);
+
+    res.json({
+      status: 'success',
+      response: response,
+    });
+  } catch (error) {
+    console.error('Error creating mall transaction:', error);
+    res.status(500).json({
+      message: 'Error al crear la transacción',
+      error: error.message,
+    });
+  }
+});
+
+
 // Confirmar transacción mall
 router.post('/mall/confirm', async (req, res) => {
   try {


### PR DESCRIPTION
- Added POST /mall/create route to handle Webpay Mall transaction creation.
- The new route initializes a transaction using the WebpayPlus MallTransaction API.
- Validates request parameters to ensure `buyOrder`, `sessionId`, and `details` are provided.
- Returns the transaction response if successful or an error message if it fails.
