### PR TITLE
FIX fetch /api/payment/create" en lugar de "/api/payment/mall/create

### DIFF
--- a/src/components/WebpayMallPayment.tsx
+++ b/src/components/WebpayMallPayment.tsx
@@ -20,7 +20,7 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
       setLoading(true);
       setError(null);
       
-      const response = await fetch('/api/payment/mall/create', {
+      const response = await fetch('/api/payment/create', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Backend (payment.js): Cambia la ruta de "/mall/create" a "/payment/create" y asegúrate de usar Webpay Plus para una tienda individual.
Frontend: Actualiza la solicitud para que apunte a la nueva ruta "/api/payment/create"