### PR TITLE
FIX: Corrección de prefijo de ruta en `payment.js` para integrarse co…

### DIFF
--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -14,7 +14,7 @@ const webpayPlus = new WebpayPlus.Transaction({
 });
 
 // Rutas para crear y confirmar la transacción
-router.post('/payment/create', async (req, res) => {
+router.post('/create', async (req, res) => {
   try {
     const { orderId, sessionId, amount, returnUrl } = req.body;
 
@@ -30,7 +30,7 @@ router.post('/payment/create', async (req, res) => {
   }
 });
 
-router.post('/payment/confirm', async (req, res) => {
+router.post('/confirm', async (req, res) => {
   try {
     const { token_ws } = req.body;
 


### PR DESCRIPTION

- Eliminado el prefijo `/payment` de las rutas en `payment.js` para evitar redundancia con el prefijo `/api/payment` ya establecido en `server.js`.
- Modificadas las rutas a `/create` y `/confirm` en `payment.js` para que, al montarse en `server.js`, se interpreten correctamente como `/api/payment/create` y `/api/payment/confirm`.
- Este ajuste soluciona el error `404` y evita que el frontend reciba HTML en lugar de JSON al llamar a la API.
