### PR TITLE
FIX: Validación y configuración de `REACT_APP_FRONTEND_URL` para defi…

### DIFF
--- a/src/components/WebpayMallPayment.tsx
+++ b/src/components/WebpayMallPayment.tsx
@@ -25,6 +25,10 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
 
       // Generar un sessionId único
       const sessionId = `SESSION-${Date.now()}`;
+          // Verificar si REACT_APP_FRONTEND_URL está definida
+    if (!process.env.REACT_APP_FRONTEND_URL) {
+      throw new Error('La variable de entorno REACT_APP_FRONTEND_URL no está definida');
+    }
 
       // Usar la variable de entorno FRONTEND_URL para definir returnUrl
       console.log('Frontend URL:', process.env.REACT_APP_FRONTEND_URL);


### PR DESCRIPTION
- Configurada la variable de entorno `REACT_APP_FRONTEND_URL` en Heroku y localmente para definir dinámicamente el parámetro `returnUrl`.
- Agregada validación en el frontend para asegurarse de que `REACT_APP_FRONTEND_URL` está definida antes de usarla.
- Añadida validación en el backend para evitar transacciones con `returnUrl` inválido.
- Este FIX garantiza que las transacciones se inicien correctamente con una URL de retorno válida.
