### PR TITLE
Mover el manejo de returnUrl al backend y eliminar referencias en el …

### DIFF
--- a/src/components/WebpayMallPayment.tsx
+++ b/src/components/WebpayMallPayment.tsx
@@ -26,11 +26,7 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
       // Generar un sessionId único
       const sessionId = `SESSION-${Date.now()}`;
 
-      // Usar la variable de entorno FRONTEND_URL para definir returnUrl
-      const returnUrl = `${import.meta.env.VITE_FRONTEND_URL}/payment/return`;
-
-
-      // Enviar la solicitud al backend
+      // Enviar la solicitud al backend sin returnUrl
       const response = await fetch('/api/payment/create', {
         method: 'POST',
         headers: {
@@ -41,7 +37,6 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
           orderId,
           sessionId,
           amount,
-          returnUrl,
         }),
       });
 

--- a/src/components/WebpayPayment.tsx
+++ b/src/components/WebpayPayment.tsx
@@ -22,14 +22,11 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
 
       // Calcular el total del monto
       const amount = items.reduce((sum, item) => sum + item.amount, 0);
-      
+
       // Generar un sessionId único
       const sessionId = `SESSION-${Date.now()}`;
-      
-      // Definir la URL de retorno
-      const returnUrl = `${import.meta.env.VITE_FRONTEND_URL}/payment/return`;
 
-
+      // Enviar la solicitud al backend sin returnUrl
       const response = await fetch('/api/payment/create', {
         method: 'POST',
         headers: {
@@ -40,7 +37,6 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
           orderId,
           sessionId,
           amount,
-          returnUrl,
         }),
       });
 

--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -18,13 +18,19 @@ router.post('/create', async (req, res) => {
   console.log("Request body:", req.body); // Agrega este log
 
   try {
-    const { orderId, sessionId, amount, returnUrl } = req.body;
+    const { orderId, sessionId, amount } = req.body;
 
-    if (!orderId || !sessionId || !amount || !returnUrl) {
+    // Verifica que los parámetros obligatorios estén presentes
+    if (!orderId || !sessionId || !amount) {
       return res.status(400).json({ message: 'Parámetros de transacción faltantes o incorrectos' });
     }
 
+    // Genera el returnUrl directamente en el backend
+    const returnUrl = `${process.env.FRONTEND_URL}/payment/result`.replace(/([^:]\/)\/+/g, "$1");
+
+    // Crea la transacción
     const response = await webpayPlus.create(orderId.toString(), sessionId.toString(), amount, returnUrl);
+
     res.json({ status: 'success', response });
   } catch (error) {
     console.error('Error creating transaction:', error);
@@ -54,6 +60,4 @@ router.post('/confirm', async (req, res) => {
   }
 });
 
-
 module.exports = router;
-


### PR DESCRIPTION
Este PR elimina el manejo de returnUrl desde el frontend y lo delega exclusivamente al backend para garantizar un flujo de transacción más seguro y controlado. Se han realizado los siguientes cambios:

Eliminación del campo returnUrl en las solicitudes al backend desde WebpayPayment.tsx y WebpayMallPayment.tsx.
Ajuste del backend para manejar internamente el returnUrl de forma automática según el entorno (integración o producción).
Se asegura que la URL de retorno esté configurada en el backend con base en la variable FRONTEND_URL.