### PR TITLE
Corrección de endpoint para confirmar transacciones Webpay

### DIFF
--- a/src/components/MallPaymentResult.tsx
+++ b/src/components/MallPaymentResult.tsx
@@ -44,7 +44,7 @@ export const MallPaymentResult: React.FC = () => {
       }
 
       try {
-        const response = await fetch('/api/payment/mall/confirm', {
+        const response = await fetch('/api/payment/confirm', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION

Ajustado el frontend para que la solicitud de confirmación apunte al endpoint correcto /api/payment/confirm.
Añadida la ruta /api/payment/mall/confirm al backend para soporte de confirmación mall (si aplica).
