### PR TITLE
Fix: Actualizar referencia de MallPaymentResult a PaymentResult

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from '../App';
-import { MallPaymentResult } from '../components/MallPaymentResult';
+import { PaymentResult } from '../components/MallPaymentResult';
 import WebpayRedirectPage from '../components/WebpayRedirectPage';
 import { CartProvider } from '../context/CartContext'; // Importa el CartProvider
 
@@ -17,7 +17,7 @@ export const router = createBrowserRouter([
     path: '/payment/result',
     element: (
       <CartProvider>
-        <MallPaymentResult />
+        <PaymentResult />
       </CartProvider>
     ),
   },


### PR DESCRIPTION
El cambio realizado resuelve un problema de referencia incorrecta en el archivo src/routes/index.tsx, donde se intentaba importar un componente llamado MallPaymentResult que ya no existía o fue renombrado a PaymentResult. Este error impedía que la aplicación se compilara correctamente en Heroku.