### PR TITLE
Archivo: MallPaymentResult.tsx

### DIFF
--- a/src/components/MallPaymentResult.tsx
+++ b/src/components/MallPaymentResult.tsx
@@ -23,7 +23,7 @@ interface PaymentResponse {
   message?: string; // Mensaje de error desde el backend
 }
 
-export const MallPaymentResult: React.FC = () => {
+export const PaymentResult: React.FC = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { dispatch } = useCart();


### PR DESCRIPTION

Problema:

El componente fue renombrado de MallPaymentResult a PaymentResult, pero la importación en index.tsx todavía busca MallPaymentResult, generando un error en el build.
Solución:

Se actualizó la exportación en el archivo del componente para reflejar el nuevo nombre PaymentResult.
Se corrigió la importación en index.tsx (y otros archivos, si aplica) para usar PaymentResult.
Impacto:

Se resuelve el error en el build asegurando consistencia entre el nombre del componente, el archivo y las importaciones.