### PR TITLE
Backend: Evitar solicitudes duplicadas y manejar errores

### DIFF
--- a/src/components/MallPaymentResult.tsx
+++ b/src/components/MallPaymentResult.tsx
@@ -31,55 +31,59 @@ export const PaymentResult: React.FC = () => {
   const [paymentDetails, setPaymentDetails] = useState<PaymentResponse | null>(null);
   const [isRequesting, setIsRequesting] = useState(false); // Previene duplicados
 
-useEffect(() => {
-  const confirmPayment = async () => {
-    const token = searchParams.get('token_ws');
-
-    if (!token) {
-      setStatus('error');
-      setPaymentDetails({ message: 'Token de transacción no encontrado.' });
-      return;
-    }
-
-    // Prevenir solicitudes duplicadas
-    if (isRequesting) return;
-    setIsRequesting(true);
-
-    try {
-      const apiBaseUrl = import.meta.env.VITE_FRONTEND_URL || window.location.origin;
-      const response = await fetch(`${apiBaseUrl}/api/payment/confirm`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ token_ws: token }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Error al confirmar el pago');
+  useEffect(() => {
+    const confirmPayment = async () => {
+      const token = searchParams.get('token_ws');
+  
+      if (!token) {
+        setStatus('error');
+        setPaymentDetails({ message: 'Token de transacción no encontrado.' });
+        return;
       }
-
-      const data = await response.json();
-
-      if (data.status === 'success') {
-        setStatus('success');
-        setPaymentDetails(data.response);
-        dispatch({ type: 'CLEAR_CART' });
-      } else {
-        throw new Error(data.message || 'Error en el pago');
+  
+      // Prevenir solicitudes duplicadas
+      if (isRequesting) {
+        console.warn('Solicitud duplicada detectada. Ignorando la solicitud.');
+        return;
       }
-    } catch (error: any) {
-      console.error('Error confirmando el pago:', error);
-      setStatus('error');
-      setPaymentDetails({ message: error.message || 'Error desconocido al procesar el pago.' });
-    } finally {
-      setIsRequesting(false);
-    }
-  };
-
-  confirmPayment();
-}, [searchParams, dispatch, isRequesting]);
+      setIsRequesting(true);
+  
+      try {
+        const apiBaseUrl = import.meta.env.VITE_FRONTEND_URL || window.location.origin;
+        const response = await fetch(`${apiBaseUrl}/api/payment/confirm`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ token_ws: token }),
+        });
+  
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.message || 'Error al confirmar el pago');
+        }
+  
+        const data = await response.json();
+  
+        if (data.status === 'success') {
+          setStatus('success');
+          setPaymentDetails(data.response);
+          dispatch({ type: 'CLEAR_CART' });
+        } else {
+          throw new Error(data.message || 'Error en el pago');
+        }
+      } catch (error: any) {
+        console.error('Error confirmando el pago:', error);
+        setStatus('error');
+        setPaymentDetails({ message: error.message || 'Error desconocido al procesar el pago.' });
+      } finally {
+        setIsRequesting(false);
+      }
+    };
+  
+    confirmPayment();
+  }, [searchParams, dispatch, isRequesting]);
+  
   
 
   const getPaymentTypeLabel = (code: string | undefined) => {


### PR DESCRIPTION
Utiliza un mapa (Map) llamado activeTokens para rastrear los token_ws que están siendo procesados.
Si un token_ws ya está en proceso, responde con un código 409 Conflict, indicando que la transacción ya está siendo procesada.
Una vez finalizado el procesamiento, libera el token después de un breve retraso (3 segundos) para permitir nuevos intentos si fuera necesario.
Evitar solicitudes duplicadas en el frontend:

Usa un estado local (isRequesting) para bloquear el envío de solicitudes repetidas mientras una solicitud está en curso.
Antes de enviar la solicitud al backend, verifica si isRequesting está en true. Si lo está, no realiza otra solicitud.
Validación estricta en el backend:

Asegúrate de que el response_code de la confirmación sea 0 y el estado sea AUTHORIZED antes de marcar la transacción como exitosa.
Si la transacción no es autorizada, devuelve un error detallado para que el usuario tenga un mensaje claro.
Mensajes de error claros:

Proporciona mensajes significativos tanto en el backend como en el frontend para que el usuario entienda si hubo un problema durante el pago.