### PR TITLE
fix/remove-unused-items-param

### DIFF
--- a/src/components/WebpayPayment.tsx
+++ b/src/components/WebpayPayment.tsx
@@ -41,9 +41,9 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
           buyOrder: orderId, // Corresponde al ID de la orden principal
           sessionId, // ID de sesión único
           amount, // Total del monto
-          items, // Lista de ítems en caso de Webpay Mall
           returnUrl: `${window.location.origin}/payment/result`, // URL de retorno
         }),
+        
       });
 
       if (!response.ok) {


### PR DESCRIPTION

Elimina el parámetro innecesario items en las solicitudes desde el frontend hacia el backend.

Este cambio ajusta la solicitud del frontend para que envíe únicamente los parámetros requeridos por el backend (buyOrder, sessionId, amount y returnUrl). El parámetro items no es necesario en el flujo actual de transacciones y su inclusión causaba errores de validación en el backend.