### PR TITLE
Archivo: WebpayMallPayment

### DIFF
--- a/src/components/WebpayMallPayment.tsx
+++ b/src/components/WebpayMallPayment.tsx
@@ -33,10 +33,10 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          items,
-          orderId,
-          sessionId,
-          amount,
+          buyOrder: orderId, // Corresponde al ID de la orden principal
+          sessionId, // ID de sesión único
+          amount, // Total del monto
+          returnUrl: `${window.location.origin}/payment/result`, // URL de retorno
         }),
       });
 


### PR DESCRIPTION

Este PR soluciona el envío de parámetros adicionales desde WebpayMallPayment. Se eliminó items del cuerpo de la solicitud, ya que no es necesario para el flujo de transacciones simples de Webpay Plus. Esto asegura compatibilidad con el endpoint /api/payment/create en el backend.