### PR TITLE
Ajustar la respuesta del backend para que sea compatible con el frontend

### DIFF
--- a/src/components/WebpayMallPayment.tsx
+++ b/src/components/WebpayMallPayment.tsx
@@ -52,8 +52,9 @@ export const WebpayMallPayment: React.FC<WebpayMallPaymentProps> = ({ orderId, i
   
       const data = await response.json();
   
-      if (data.url && data.token) {
-        setPaymentData({ token: data.token, url: data.url });
+      // Cambia la forma en que accedes a token y url
+      if (data.response?.url && data.response?.token) {
+        setPaymentData({ token: data.response.token, url: data.response.url });
       } else {
         throw new Error('Respuesta inválida del servidor');
       }


### PR DESCRIPTION
Se ajustó la estructura de la respuesta en la ruta /create del backend para que envíe las propiedades token y url directamente en la raíz del objeto JSON, en lugar de anidarlas dentro de un campo adicional (response). Esto asegura la compatibilidad con el frontend, que espera acceder directamente a estas propiedades para procesar el pago.